### PR TITLE
Add configuration for lua-language-server.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -195,8 +195,12 @@ local clangd = {name = 'clangd', cmd = 'clangd'}
 -- https://github.com/python-lsp/python-lsp-server
 local pyls = {name = 'python-lsp-sever', cmd = 'pylsp'}
 
+-- lua (lua-language-server) language server configuration
+-- https://github.com/sumneko/lua-language-server
+local luals = {name = 'lua-language-server', cmd = 'lua-language-server'}
+
 -- map of known language servers per syntax
-lspc.ls_map = {cpp = clangd, ansi_c = clangd, python = pyls}
+lspc.ls_map = {cpp = clangd, ansi_c = clangd, python = pyls, lua = luals}
 
 -- return the name of the language server for this syntax
 local function get_ls_name_for_syntax(syntax)


### PR DESCRIPTION
Refer to #2 for more. It is a shame, that we don't have Lua LSP server configuration.

Perhaps instead of various nonsensical local variables (`clangd`, `pyls`, `luals`) we could one huge Lua table literal?