### PR TITLE
fix diagnostic highlighting and message

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -575,9 +575,17 @@ local function lspc_highlight_diagnostics(win, diagnostics, style)
   for _, diagnostic in ipairs(diagnostics) do
     if lspc.highlight_diagnostics == 'range' then
       local range = diagnostic.vis_range
+
       -- make sure to highlight only ranges which actually contain the diagnostic
+      local finish = range.finish - 1
+
+      -- in some instances the range defined by the diagnostic message starts and ends at the same position
+      if finish < range.start then
+	      finish = range.finish
+      end
+
       if diagnostic.content == win.file:content(range) then
-        win:style(style, range.start, range.finish - 1)
+        win:style(style, range.start, finish)
       end
 
     elseif lspc.highlight_diagnostics == 'line' then
@@ -1337,7 +1345,7 @@ local function lspc_show_diagnostic(ls, win, line)
   for _, diagnostic in ipairs(diagnostics_to_show) do
     diagnostics_msg = diagnostics_msg ..
                           string.format(diagnostics_fmt, diagnostic.start.line,
-                                        diagnostic.start.col, diagnostic.code, diagnostic.message)
+                                        diagnostic.start.col, diagnostic.code or 'error', diagnostic.message)
   end
 
   if diagnostics_msg ~= '' then


### PR DESCRIPTION
Hi,

These errors were found using the Go Langauge Server (gopls). I know that it isn't listed in
`supported-servers.lua` but besides these diagnostic isues I have had a great time, so thank you for vis-lspc!

You will have to excuse my lack of understanding the Language Server Protocol.

What I have found out is that some LSPs sends `textDocument/publishDiagnostics` where the diagnostic starts and ends at the same line and character resulting in no highlighting at all.

I also noticed that `textDocument/publishDiagnostics` doesn't always have a `code` field, resulting in `diagnostic.code` being nil and so it is replaced with `error` in those cases.


Please let me know if you would like more information regarding this, I can provide a sample code if needed.