### PR TITLE
misc

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -653,29 +653,6 @@ local function vis_apply_workspaceEdit(_, _, workspaceEdit)
     end
   end
 
-  -- generate change summary
-  local summary = '--- workspace edit summary ---\n'
-  for uri, edits in pairs(file_edits) do
-    local path = uri_to_path(uri)
-    summary = summary .. path .. ':\n'
-    for i, edit in ipairs(edits) do
-      summary = summary .. '\t' .. i .. '.: ' .. json.encode(edit) .. '\n'
-    end
-  end
-
-  _show_message(summary)
-  vis:redraw()
-
-  -- get user confirmation
-  local confirmation = lspc_confirm('apply changes:')
-
-  -- close summary window
-  vis:command('q')
-
-  if not confirmation then
-    return
-  end
-
   -- apply changes to open files
   for uri, edits in pairs(file_edits) do
     local path = uri_to_path(uri)

--- a/init.lua
+++ b/init.lua
@@ -1754,6 +1754,23 @@ vis.events.subscribe(vis.events.FILE_OPEN, function(file)
   lspc_open(ls, win, file)
 end)
 
+vis.events.subscribe(vis.events.FILE_SAVE_POST, function(file, path)
+  if not vis.win or vis.win.file ~= file then
+    return
+  end
+
+  local ls = lspc_get_usable_ls(vis.win.syntax)
+  if not ls then
+    return
+  end
+
+  if not ls.open_files[path] then
+    lspc_open(ls, vis.win, file)
+  end
+
+  ls_send_did_change(ls, file)
+end)
+
 vis:option_register('lspc-highlight-diagnostics', 'string', function(value)
   lspc.highlight_diagnostics = value
   return true

--- a/init.lua
+++ b/init.lua
@@ -1680,5 +1680,10 @@ vis:option_register('lspc-confirm-cmd', 'string', function(value)
   return true
 end, 'External tool vis-lspc uses to ask the user for confirmation')
 
+vis:option_register('lspc-message-level', 'number', function(value)
+  lspc.message_level = value
+  return true
+end, 'Message level to show in UI (for server messages)')
+
 dofile(source_path .. 'bindings.lua')
 return lspc

--- a/init.lua
+++ b/init.lua
@@ -321,11 +321,7 @@ local function lspc_select(choices)
     return choices[1]
   end
 
-  local status, output
-  local cmd = 'printf "' .. menu_input .. '" | ' .. lspc.menu_cmd
-  lspc.log('collect choice using: ' .. cmd)
-
-  status, output = vis:pipe(vis.win.file, {start = 0, finish = 0}, cmd)
+  local status, output = vis:pipe_buffer(menu_input, lspc.menu_cmd)
 
   local choice = nil
   if status == 0 then
@@ -414,20 +410,14 @@ end
 -- return true if user selected yes, false otherwise
 local function lspc_confirm(prompt)
   local choices = 'no\nyes'
-
-  local cmd = 'printf "' .. choices .. '" | ' .. lspc.confirm_cmd
+  local cmd = lspc.confirm_cmd
 
   if prompt then
     cmd = cmd .. ' -p \'' .. prompt .. '\''
   end
 
-  lspc.log('get confirmation using: ' .. cmd)
-  -- local menu = io.popen(cmd)
-  -- local output = menu:read('*a')
-  -- local _, _, status = menu:close()
-
   local choice = nil
-  local status, output = vis:pipe(vis.win.file, {start = 0, finish = 0}, cmd)
+  local status, output = vis:pipe_buffer(choices, cmd)
   if status == 0 then
     -- trim newline from selection
     if output:sub(-1) == '\n' then

--- a/init.lua
+++ b/init.lua
@@ -841,6 +841,14 @@ local function lspc_handle_completion_method_response(win, result, old_pos)
   lspc_err('Unsupported completion')
 end
 
+local function _show_markdown_message(msg)
+  vis:command("open")
+  vis:command("set syntax markdown")
+
+  vis.win.file:insert(0, msg)
+  vis.win.selection.pos = 0
+end
+
 local function lspc_handle_hover_method_response(win, result, old_pos)
   if not result or not result.contents then
     lspc_warn('no hover available')
@@ -848,13 +856,14 @@ local function lspc_handle_hover_method_response(win, result, old_pos)
   end
 
   local sel = vis_pos_to_sel(win, old_pos)
-  local hover_header =
-      '--- hover: ' .. (win.file.path or '') .. ':' .. sel.line .. ', ' .. sel.col .. ' ---'
 
-  local hover_msg = ''
   -- result is MarkedString[]
   if type(result.contents) == 'table' and #result.contents > 0 then
     lspc.log('hover returned list of length ' .. #result.contents)
+
+    local hover_header = '--- hover: ' .. (win.file.path or '') .. ':' .. sel.line .. ', ' .. sel.col .. ' ---'
+    local hover_msg = ''
+
     for i, v in ipairs(result.contents) do
       if i == 1 then
         hover_msg = v.value or v
@@ -862,11 +871,13 @@ local function lspc_handle_hover_method_response(win, result, old_pos)
         hover_msg = hover_msg .. '\n---\n' .. (v.value or v)
       end
     end
+
+    vis:message(hover_header .. '\n' .. hover_msg)
     -- result is either MarkedString or MarkupContent
   else
-    hover_msg = result.contents.value or result.contents
+    _show_markdown_message(result.contents.value or result.contents)
   end
-  vis:message(hover_header .. '\n' .. hover_msg)
+
 end
 
 local function lspc_handle_signature_help_method_response(win, result, call_pos)

--- a/init.lua
+++ b/init.lua
@@ -1040,6 +1040,8 @@ local function lspc_handle_initialize_response(ls, result)
       settings = ls.settings,
     })
   end
+
+  vis.events.emit(lspc.events.LS_INITIALIZED, ls)
 end
 
 -- method response dispatcher
@@ -1784,6 +1786,12 @@ vis.events.subscribe(vis.events.FILE_SAVE_POST, function(file, path)
   end
 
   ls_send_did_change(ls, file)
+end)
+
+vis.events.subscribe(lspc.events.LS_INITIALIZED, function(ls)
+  if vis.win and vis.win.file and lspc_get_usable_ls(vis.win.syntax) == ls then
+    lspc_open(ls, vis.win, vis.win.file)
+  end
 end)
 
 vis:option_register('lspc-highlight-diagnostics', 'string', function(value)

--- a/init.lua
+++ b/init.lua
@@ -344,6 +344,7 @@ end
 local function _file_iterator_to_n(path)
   local file = io.open(path, "r")
   local lines = file:lines()
+  local last_line = nil
   local _n = 1
 
   return function(n)
@@ -353,12 +354,20 @@ local function _file_iterator_to_n(path)
     end
 
     if n < _n then
+      -- We might have multiple references on the same line, so we can
+      -- get called again with the previous line number
+      if (n + 1) == _n then
+        return last_line
+      end
+
       return nil
     end
 
     for line in lines do
       if n == _n then
         _n = _n + 1
+        last_line = line
+
         return line
       end
 

--- a/init.lua
+++ b/init.lua
@@ -167,10 +167,13 @@ end
 
 -- mapping function between vis lexer names and LSP languageIds
 local function syntax_to_languageId(syntax)
-  if syntax == 'ansi_c' then
-    return 'c'
-  end
-  return syntax
+  local map = {
+    ansi_c = 'c',
+    javascript = 'jsx',
+    typescript = 'tsx',
+  }
+
+  return map[syntax] or syntax
 end
 
 -- map of known language servers per syntax

--- a/init.lua
+++ b/init.lua
@@ -627,6 +627,13 @@ local function vis_apply_textEdits(win, file, textEdits)
   win:draw()
 end
 
+local function _show_message(msg)
+  vis:command("open")
+
+  vis.win.file:insert(0, msg)
+  vis.win.selection.pos = 0
+end
+
 -- apply a WorkspaceEdit received from the language server
 local function vis_apply_workspaceEdit(_, _, workspaceEdit)
   local file_edits = workspaceEdit.changes
@@ -653,7 +660,7 @@ local function vis_apply_workspaceEdit(_, _, workspaceEdit)
     end
   end
 
-  vis:message(summary)
+  _show_message(summary)
   vis:redraw()
 
   -- get user confirmation
@@ -960,7 +967,7 @@ local function lspc_handle_hover_method_response(win, result, old_pos)
   if type(result.contents) == 'table' and #result.contents > 0 then
     lspc.log('hover returned list of length ' .. #result.contents)
 
-    local hover_header = '--- hover: ' .. (win.file.path or '') .. ':' .. sel.line .. ', ' .. sel.col .. ' ---'
+    local hover_header = '--- hover: ' .. (win.file.path or '') .. ': ' .. sel.line .. ', ' .. sel.col .. ' ---'
     local hover_msg = ''
 
     for i, v in ipairs(result.contents) do
@@ -971,7 +978,7 @@ local function lspc_handle_hover_method_response(win, result, old_pos)
       end
     end
 
-    vis:message(hover_header .. '\n' .. hover_msg)
+    _show_message(hover_header .. '\n' .. hover_msg)
     -- result is either MarkedString or MarkupContent
   else
     _show_markdown_message(result.contents.value or result.contents)
@@ -988,7 +995,7 @@ local function lspc_handle_signature_help_method_response(win, result, call_pos)
   local signatures = result.signatures
 
   local sel = vis_pos_to_sel(win, call_pos)
-  local help_header = '--- signature help: ' .. (win.file.path or '') .. ':' .. sel.line .. ', ' ..
+  local help_header = '--- signature help: ' .. (win.file.path or '') .. ': ' .. sel.line .. ', ' ..
                           sel.col .. ' ---'
 
   -- local help_msg = json.encode(result)
@@ -1001,7 +1008,7 @@ local function lspc_handle_signature_help_method_response(win, result, call_pos)
     end
     help_msg = help_msg .. '\n' .. sig_msg
   end
-  vis:message(help_header .. help_msg)
+  _show_message(help_header .. help_msg)
 end
 
 local function lspc_handle_rename_method_response(win, result)
@@ -1499,7 +1506,7 @@ local function lspc_show_diagnostic(ls, win, line)
     end
   end
 
-  local diagnostics_fmt = '%d:%d %s:%s\n'
+  local diagnostics_fmt = '%d:%d %s: %s\n'
   local diagnostics_msg = ''
   for _, diagnostic in ipairs(diagnostics_to_show) do
     diagnostics_msg = diagnostics_msg ..
@@ -1509,7 +1516,7 @@ local function lspc_show_diagnostic(ls, win, line)
   end
 
   if diagnostics_msg ~= '' then
-    vis:message(diagnostics_msg)
+    _show_message(diagnostics_msg)
   else
     lspc_warn('No diagnostics available for line: ' .. line)
   end

--- a/init.lua
+++ b/init.lua
@@ -703,7 +703,17 @@ local function lspc_highlight_diagnostics(win, diagnostics, style)
     style = lspc.diagnostic_style_id
   end
 
+  local level_mapping = {
+      [1] = lspc.diagnostic_styles.error,
+      [2] = lspc.diagnostic_styles.warning,
+      [3] = lspc.diagnostic_styles.information,
+      [4] = lspc.diagnostic_styles.hint
+  }
+
   for _, diagnostic in ipairs(diagnostics) do
+    local diagnostic_style = level_mapping[diagnostic.severity] or level_mapping[1]
+    assert(win:style_define(lspc.diagnostic_style_id, diagnostic_style))
+
     if lspc.highlight_diagnostics == 'range' then
       local range = diagnostic.vis_range
 
@@ -1719,8 +1729,6 @@ vis.events.subscribe(vis.events.WIN_OPEN, function(win)
   if lspc.autostart and win.syntax then
     ls_start_server(win.syntax)
   end
-
-  assert(win:style_define(lspc.diagnostic_style_id, lspc.diagnostic_style))
 end)
 
 vis.events.subscribe(vis.events.WIN_HIGHLIGHT, function(win)
@@ -1790,6 +1798,22 @@ vis:option_register('lspc-message-level', 'number', function(value)
   lspc.message_level = value
   return true
 end, 'Message level to show in UI (for server messages)')
+
+vis:option_register('lspc-diagnostic-style-error', 'string', function(value)
+  lspc.diagnostic_styles.error = value
+end, 'Style for diagnostic errors')
+
+vis:option_register('lspc-diagnostic-style-warning', 'string', function(value)
+  lspc.diagnostic_styles.warning = value
+end, 'Style for diagnostic warnings')
+
+vis:option_register('lspc-diagnostic-style-information', 'string', function(value)
+  lspc.diagnostic_styles.information = value
+end, 'Style for diagnostic information')
+
+vis:option_register('lspc-diagnostic-style-hint', 'string', function(value)
+  lspc.diagnostic_styles.hint = value
+end, 'Style for diagnostic hints')
 
 dofile(source_path .. 'bindings.lua')
 return lspc

--- a/init.lua
+++ b/init.lua
@@ -325,14 +325,7 @@ local function lspc_select(choices)
   local cmd = 'printf "' .. menu_input .. '" | ' .. lspc.menu_cmd
   lspc.log('collect choice using: ' .. cmd)
 
-  if lspc.menu_cmd:sub(0, 8) == 'vis-menu' then
-    status, output = vis:pipe(vis.win.file, {start = 0, finish = 0}, cmd)
-  else
-    local menu = io.popen(cmd)
-    output = menu:read('*a')
-    local _, _, _status = menu:close()
-    status = _status
-  end
+  status, output = vis:pipe(vis.win.file, {start = 0, finish = 0}, cmd)
 
   local choice = nil
   if status == 0 then

--- a/lspc.lua
+++ b/lspc.lua
@@ -85,6 +85,7 @@ local client_capabilites = {
     },
     declaration = {dynamicRegistration = false, linkSupport = true},
     definition = goto_methods_capabilities,
+    publishDiagnostics = {relatedInformation = false},
     typeDefinition = goto_methods_capabilities,
     implementation = goto_methods_capabilities,
     references = {dynamicRegistration = false},

--- a/lspc.lua
+++ b/lspc.lua
@@ -47,6 +47,11 @@ local lspc = {
   -- message level to show in the UI when receiving messages from the server
   -- Error = 1, Warning = 2, Info = 3, Log = 4
   message_level = 3,
+
+  -- events
+  events = {
+    LS_INITIALIZED = 'LspcEvent::LS_INITIALIZED',
+  },
 }
 
 --

--- a/lspc.lua
+++ b/lspc.lua
@@ -47,7 +47,7 @@ local lspc = {
 --
 --- ClientCapabilities we tell the language server when calling "initialize"
 --
-local supported_markup_kind = {'plaintext'}
+local supported_markup_kind = {'markdown'}
 
 local goto_methods_capabilities = {
   linkSupport = true,
@@ -61,14 +61,14 @@ local client_capabilites = {
   },
   textDocument = {
     synchronization = {dynamicRegistration = false, didSave = true},
-    -- ask the server to send us only plaintext completionItems
+    -- ask the server to send us only markdown completionItems
     completion = {
       dynamicRegistration = false,
       completionItem = {documentationFormat = supported_markup_kind},
     },
-    -- ask the server to send us only plaintext hover results
+    -- ask the server to send us only markdown hover results
     hover = {dynamicRegistration = false, contentFormat = supported_markup_kind},
-    -- ask the server to send us only plaintext signatureHelp results
+    -- ask the server to send us only markdown signatureHelp results
     signatureHelp = {
       dynamicRegistration = false,
       signatureInformation = {documentationFormat = supported_markup_kind},

--- a/lspc.lua
+++ b/lspc.lua
@@ -35,9 +35,14 @@ local lspc = {
   highlight_diagnostics = false,
   -- style id used by lspc to register the style used to highlight diagnostics
   diagnostic_style_id = 64, -- 64 is the last style id available for the lexer styles. See vis/ui.h.
-  -- style used by lspc to highlight the diagnostic range
-  -- 60% solarized red
-  diagnostic_style = 'back:#e3514f',
+  -- styles used by lspc to highlight the diagnostic range
+  -- must be set by the user
+  diagnostic_styles = {
+    error = 'fore:default,back:default',
+    warning = 'fore:default,back:default',
+    information = 'fore:default,back:default',
+    hint = 'fore:default,back:default',
+  },
 
   -- message level to show in the UI when receiving messages from the server
   -- Error = 1, Warning = 2, Info = 3, Log = 4

--- a/supported-servers.lua
+++ b/supported-servers.lua
@@ -62,4 +62,8 @@ return {
   -- go (gopls)
   -- https://github.com/golang/tools/tree/master/gopls
   go = {name = 'go', cmd = 'gopls'},
+
+  -- rust (rust-analyzer)
+  -- https://github.com/rust-lang/rust-analyzer
+  rust = {name = 'rust', cmd = 'rust-analyzer'}
 }

--- a/supported-servers.lua
+++ b/supported-servers.lua
@@ -58,4 +58,8 @@ return {
   -- ocaml (ocaml-language-server)
   -- https://github.com/ocaml/ocaml-lsp
   caml = {name = 'ocaml', cmd = 'ocamllsp'},
+
+  -- go (gopls)
+  -- https://github.com/golang/tools/tree/master/gopls
+  go = {name = 'go', cmd = 'gopls'},
 }

--- a/supported-servers.lua
+++ b/supported-servers.lua
@@ -20,10 +20,11 @@ local source_path = source_str:match('(.*/)')
 
 local lspc = dofile(source_path .. 'lspc.lua')
 
-local clangd = {name = 'clangd', cmd = 'clangd'}
+local clangd = {name = 'clangd', cmd = 'clangd', roots = {'compile_commands.json', '.clangd'}}
 local typescript = {
   name = 'typescript',
   cmd = 'typescript-language-server --stdio',
+  roots = {'package.json', 'tsconfig.json', 'jsconfig.json'},
 }
 
 return {
@@ -31,7 +32,7 @@ return {
   ansi_c = clangd,
   -- pylsp (python-lsp-server) language server configuration
   -- https://github.com/python-lsp/python-lsp-server
-  python = {name = 'python-lsp-server', cmd = 'pylsp'},
+  python = {name = 'python-lsp-server', cmd = 'pylsp', roots = {'requirements.txt', 'setup.py'}},
   -- lua (lua-language-server) language server configuration
   -- https://github.com/sumneko/lua-language-server
   lua = {
@@ -50,20 +51,21 @@ return {
   dart = {
     name = 'dart',
     cmd = 'dart language-server --client-id vis-lspc --client-version ' .. lspc.version,
+    roots = {'pubspec.yaml'},
   },
   -- haskell (haskell-language-server)
   -- https://github.com/haskell/haskell-language-server
-  haskell = {name = 'haskell', cmd = 'haskell-language-server-wrapper --lsp'},
+  haskell = {name = 'haskell', cmd = 'haskell-language-server-wrapper --lsp', roots = {'hie.yaml', 'cabal.project', 'Setup.hs', 'stack.yaml', '*.cabal'}},
 
   -- ocaml (ocaml-language-server)
   -- https://github.com/ocaml/ocaml-lsp
-  caml = {name = 'ocaml', cmd = 'ocamllsp'},
+  caml = {name = 'ocaml', cmd = 'ocamllsp', roots = {'dune-workspace', 'dune-project', 'Makefile', 'opam', '*.opam', 'esy.json', 'dune'}},
 
   -- go (gopls)
   -- https://github.com/golang/tools/tree/master/gopls
-  go = {name = 'go', cmd = 'gopls'},
+  go = {name = 'go', cmd = 'gopls', roots = {'Gopkg.toml', 'go.mod'}},
 
   -- rust (rust-analyzer)
   -- https://github.com/rust-lang/rust-analyzer
-  rust = {name = 'rust', cmd = 'rust-analyzer'}
+  rust = {name = 'rust', cmd = 'rust-analyzer', roots = {'Cargo.toml'}}
 }

--- a/tools/find-root
+++ b/tools/find-root
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -eu
+
+if [ ! "${1:-}" ]; then
+    exit 1
+fi
+
+BASEDIR="$(dirname "$1")"
+
+while read -r glob; do
+    cd "$BASEDIR"
+
+    while [ "$PWD" != "/" ]; do
+        set -- $glob
+
+        if [ -e "$1" ]; then
+            echo "$PWD"
+            exit 0
+        fi
+
+        cd ..
+    done
+done
+
+echo "$BASEDIR"


### PR DESCRIPTION
Hey, I've been maintaining a fork of vis-lspc to adapt it to my needs, just dropping this PR here so you can cherry pick any commits you might find useful. Most commits are atomic, some changes:

- Fetch the line's content from the file (either by re-using the existing vis buffer or opening it via the general lua APIs)
- Convert paths to relative paths so more content is visible when being piped to a program like `fzy`
- Hover messages are requested in markdown
- Different styling for each type of diagnostic message
- `vis:pipe` refactors to use [`vis:pipe_buffer`](https://github.com/martanne/vis/pull/1177), as I noticed the `printf` command construction breaking in large codebases
 
If you'd be interested in having some of this upstream I can create individual PRs

Thanks a lot for creating this project!